### PR TITLE
Add sidebar link for Credhub Maestro cert rotation docs

### DIFF
--- a/subnavs/_pivotalcf-subnav-2-8.erb
+++ b/subnavs/_pivotalcf-subnav-2-8.erb
@@ -425,6 +425,9 @@
                     <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/api-cert-rotation.html">Rotating Certificates</a>
                   </li>
                   <li class="">
+                    <a href="https://docs.pivotal.io/platform/<%= vars.current_major_version.sub('.', '-') %>/security/pcf-infrastructure/advanced-certificate-rotation.html">Advanced Certificate Rotation with CredHub Maestro</a>
+                  </li>
+                  <li class="">
                     <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/custom-ca-cert.html">Custom Certificate Authorities</a>
                   </li>
                   <li class="">


### PR DESCRIPTION
This is the sidebar link for https://github.com/pivotal-cf/docs-pcf-security/pull/58