### PR TITLE
Corrected and highlighted default values

### DIFF
--- a/core/2-8/_mysql_proxy_config.html.md.erb
+++ b/core/2-8/_mysql_proxy_config.html.md.erb
@@ -4,9 +4,9 @@ To configure the **Internal MySQL** pane:
 
 1. Select **Internal MySQL**.
 
-1. In the **Replication canary time period** field, specify how frequently the canary checks for replication failure. Leave the default of 30 seconds or modify the value based on the needs of your deployment. Lower numbers cause the canary to run more frequently, which means that the canary reacts more quickly to replication failure but adds load to the database.
+1. In the **Replication canary time period** field, specify how frequently the canary checks for replication failure. Leave the default of `30` seconds or modify the value based on the needs of your deployment. Lower numbers cause the canary to run more frequently, which means that the canary reacts more quickly to replication failure but adds load to the database.
 
-1. In the **Replication canary read delay** field, specify how long the canary waits, in seconds, before verifying that data is replicating across each MySQL node. Leave the default of 20 seconds or modify the value based on the needs of your deployment. Clusters under heavy load can experience a small replication lag as write-sets are committed across the nodes.
+1. In the **Replication canary read delay** field, specify how long the canary waits, in seconds, before verifying that data is replicating across each MySQL node. Leave the default of `20` seconds or modify the value based on the needs of your deployment. Clusters under heavy load can experience a small replication lag as write-sets are committed across the nodes.
 
 1. In the **Email address** field, enter the email address where the MySQL service sends alerts when the cluster experiences a replication issue or when a node is not allowed to auto-rejoin the cluster. 
 
@@ -15,18 +15,18 @@ To configure the **Internal MySQL** pane:
 1. To allow admin and read-only admin users to connect from any remote host, enable the **Allow remote admin access** checkbox. When the checkbox is disabled, admins must `bosh ssh` into each MySQL VM to connect as the MySQL super user.
 	<p class="note"><strong>Note:</strong> Network configuration and ASG restrictions may still limit a client's ability to establish a connection with the databases.</p>
 
-1. In the **Cluster probe timeout** field, enter the maximum amount of time, in seconds, that a new node searches for existing cluster nodes. If left blank, the default value is 10 seconds.
+1. In the **Cluster probe timeout** field, enter the maximum amount of time, in seconds, that a new node searches for existing cluster nodes. If left blank, the default value is `10` seconds.
 
-1. In the **Maximum connections** field, enter the maximum number of connections allowed to the database. If left blank, the default value is `1500`.
+1. In the **Maximum connections** field, enter the maximum number of connections allowed to the database. The default value is `3500`.
 
 1. To log audit events for internal MySQL, select **Enable server activity logging** under **Server activity logging**.
 	* In the **Event types** field, you can enter the events you want the MySQL service to log. By default, this field includes `connect` and `query`, which tracks who connects to the system and what queries are processed. For more information about which events the Percona MySQL server can log, see [Audit Log Plugin](https://www.percona.com/doc/percona-server/5.7/management/audit_log_plugin.html) in the Percona documentation.
 	<p class='note'><strong>Note:</strong> Internal MySQL audit logs are not forwarded to the syslog server because they can contain personally identifying information (PII) and secrets.<br />
 	You can use the <code>download-logs</code> script to retrieve the logs, which each MySQL cluster node VM stores in <code>/var/vcap/store/mysql\_audit\_logs/</code>. For more information, see <a href="https://community.pivotal.io/s/article/script-to-download-mysql-logs-for-pas-tile-ha-clusters">Script to download MySQL logs for PAS or Tile HA Clusters</a> in the Pivotal Knowledge Base.</p>
 
-1. In the **Load balancer healthy threshold** field, enter the amount of time, in seconds, to wait until reporting that the MySQL Proxy instance has started. This allows an external load balancer time to register the instance as healthy.
+1. In the **Load balancer healthy threshold** field, enter the amount of time, in seconds, to wait until reporting that the MySQL Proxy instance has started. This allows an external load balancer time to register the instance as healthy. The default value is `0` seconds.
 
-1. In the **Load balancer unhealthy threshold** field, enter the amount of time, in seconds, that the MySQL Proxy continues to accept connections before shutting down. During this period, the health check reports the MySQL Proxy instance as unhealthy to cause load balancers to fail over to other proxies. You must enter a value greater than or equal to the maximum time it takes your load balancer to consider a proxy instance unhealthy, given repeated failed health checks.
+1. In the **Load balancer unhealthy threshold** field, enter the amount of time, in seconds, that the MySQL Proxy continues to accept connections before shutting down. During this period, the health check reports the MySQL Proxy instance as unhealthy to cause load balancers to fail over to other proxies. You must enter a value greater than or equal to the maximum time it takes your load balancer to consider a proxy instance unhealthy, given repeated failed health checks. The default is `30` seconds.
 
 1. To enable MySQL Proxy to listen on port 3336, select the **Enable inactive MySQL port** checkbox. When you run MySQL in high availability mode, this feature allows you to connect to a MySQL node that is not currently serving traffic so that you can run auditing and reporting queries without affecting performance.
 


### PR DESCRIPTION
We checked out the default values of an unconfigured PAS 2.8, and noticed some of the default values in the docs either did not match up, or were missing. Also made highlighting of values consistent.