### PR TITLE
Add link to CredHub Maestro tile compatibility page in sidebar

### DIFF
--- a/subnavs/_pivotalcf-subnav-2-8.erb
+++ b/subnavs/_pivotalcf-subnav-2-8.erb
@@ -427,12 +427,6 @@
                   <li class="">
                     <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/api-cert-rotation.html">Rotating Certificates</a>
                   </li>
-		            <li class="">
-                    <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/getting-started-with-maestro-cli.html">Getting Started with CredHub Maestro</a>
-                  </li>
-                  <li class="">
-                    <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/advanced-certificate-rotation.html">Advanced Certificate Rotation with CredHub Maestro</a>
-                  </li>
                   <li class="">
                     <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/custom-ca-cert.html">Custom Certificate Authorities</a>
                   </li>
@@ -450,6 +444,15 @@
                       </li>
                       <li class="">
                         <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/manual-credhub-certificate.html">Reviewing and Resetting Manually Set Certificates in BOSH CredHub</a>
+                      </li>
+                      <li class="">
+                        <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/getting-started-with-maestro-cli.html">Getting Started with CredHub Maestro</a>
+                      </li>
+                      <li class="">
+                        <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/advanced-certificate-rotation.html">Advanced Certificate Rotation with CredHub Maestro</a>
+                      </li>
+                      <li class="">
+                        <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/maestro-tile-compatibility.html">CredHub Maestro Tile Compatibility</a>
                       </li>
                     </ul>
                   </li>

--- a/subnavs/_pivotalcf-subnav-2-9.erb
+++ b/subnavs/_pivotalcf-subnav-2-9.erb
@@ -424,12 +424,6 @@
                      <li class="">
                         <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/api-cert-rotation.html">Rotating Certificates</a>
                      </li>
-		               <li class="">
-                        <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/getting-started-with-maestro-cli.html">Getting Started with CredHub Maestro</a>
-                     </li>
-                     <li class="">
-                        <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/advanced-certificate-rotation.html">Advanced Certificate Rotation with CredHub Maestro</a>
-                     </li>
                      <li class="">
                         <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/custom-ca-cert.html">Custom Certificate Authorities</a>
                      </li>
@@ -437,7 +431,7 @@
                         <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/customizing/credentials.html">Retrieving Credentials from Your Deployment</a>
                      </li>
                      <li class="has_submenu">
-                     <span role="button"><strong>Component: CredHub</strong></span>
+                        <span role="button"><strong>Component: CredHub</strong></span>
                         <ul>
                            <li class="">
                               <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/credhub/index.html">CredHub</a>
@@ -447,6 +441,15 @@
                            </li>
                            <li class="">
                               <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/manual-credhub-certificate.html">Reviewing and Resetting Manually Set Certificates in BOSH CredHub</a>
+                           </li>
+                           <li class="">
+                              <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/getting-started-with-maestro-cli.html">Getting Started with CredHub Maestro</a>
+                           </li>
+                           <li class="">
+                              <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/advanced-certificate-rotation.html">Advanced Certificate Rotation with CredHub Maestro</a>
+                           </li>
+                           <li class="">
+                              <a href="https://docs.pivotal.io/platform/<%= product_info['local_product_version'].to_s.sub('.','-') %>/security/pcf-infrastructure/maestro-tile-compatibility.html">CredHub Maestro Tile Compatibility</a>
                            </li>
                         </ul>
                      </li>


### PR DESCRIPTION
- Add link to Credhub tile compatibility page in sidebar for 2.8 and 2.9.
- Move other maestro pages to fall under 'Component: CredHub'

The following PRs are to add the page to the pcf-security docs for 2.8 and 2.9:
- https://github.com/pivotal-cf/docs-pcf-security/pull/64
- https://github.com/pivotal-cf/docs-pcf-security/pull/63