### PR TITLE
The example for S3 URL Endpoint is wrong

### DIFF
--- a/core/2-7/_filestore_s3_config.html.md.erb
+++ b/core/2-7/_filestore_s3_config.html.md.erb
@@ -1,7 +1,7 @@
 To use an external S3-compatible filestore for PAS file storage:
 
 1. Select **External S3-compatible filestore** and complete the following fields:
-    * Enter the `https://` **URL endpoint** for your region. For example, `https://s3-us-west-2.amazonaws.com/`.
+    * Enter the `https://` **URL endpoint** for your region. For example, `https://s3.us-west-2.amazonaws.com/`.
     * If you use an AWS instance profile to manage role information for your filestore, enable the **S3 AWS with instance profile** checkbox. For more information, see [AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) in the AWS documentation.
     <br />
     <%= image_tag("images/external-s3-filestore-instance-profile.png", alt: "At the top of the image is an enabled checkbox labeled 'S3 AWS with instance profile'. Below this checkbox are two fields labeled 'Access key' and 'Secret key'. The 'Secret key' field contains the ghost text 'Secret'.") %>


### PR DESCRIPTION
According to the format for AWS Service Endpoint URL as mentioned below,
https://docs.aws.amazon.com/general/latest/gr/rande.html

the example URL (https://s3-us-west-2.amazonaws.com/) is wrong. It should be "https://s3.us-west-2.amazonaws.com/."