### PR TITLE
Clarify credhub command for NEW-CERT

### DIFF
--- a/certs/_rotating-certs.html.md.erb
+++ b/certs/_rotating-certs.html.md.erb
@@ -169,6 +169,8 @@ Generate a new certificate signed by the CredHub root CA:
         - `COMMON-NAME` is the common name of the generated certificate.
         - `PATH-TO-ROOT-CA` is the name of CA used to sign the generated certificate.
 
+	**Note**: If `NEW-CERT` already exists, remove it with `credhub delete` before running the `credhub generate`.
+
         For example:
         <pre class="terminal">
         $ credhub generate \


### PR DESCRIPTION
We want to be more helpful to the operator to let them know that `credhub generate --no-overwrite` will not make a new certificate if the certificate already exists.

We considered changing the `credhub generate` command to remove the `--no-overwrite` flag, but it's better to make the operator more aware that the certificate may exist and he or she should check first.

[#171161837](https://www.pivotaltracker.com/story/show/171161837)