### PR TITLE
Removes messaging-nats

### DIFF
--- a/subnavs/_pivotalcf-subnav-2-10.erb
+++ b/subnavs/_pivotalcf-subnav-2-10.erb
@@ -637,9 +637,6 @@
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                            </li>
                            <li class="">
-                              <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/messaging-nats.html">Messaging (NATS)</a>
-                           </li>
-                           <li class="">
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
                            </li>
                            <li class="">

--- a/subnavs/_pivotalcf-subnav-2-11.erb
+++ b/subnavs/_pivotalcf-subnav-2-11.erb
@@ -478,9 +478,6 @@
                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                      </li>
                      <li class="">
-                        <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/messaging-nats.html">Messaging (NATS)</a>
-                     </li>
-                     <li class="">
                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
                      </li>
                      <li class="">

--- a/subnavs/_pivotalcf-subnav-2-7.erb
+++ b/subnavs/_pivotalcf-subnav-2-7.erb
@@ -625,9 +625,6 @@
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                          </li>
                          <li class="">
-                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/messaging-nats.html">Messaging (NATS)</a>
-                         </li>
-                         <li class="">
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
                          </li>
                          <li class="">

--- a/subnavs/_pivotalcf-subnav-2-8.erb
+++ b/subnavs/_pivotalcf-subnav-2-8.erb
@@ -637,9 +637,6 @@
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                          </li>
                          <li class="">
-                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/messaging-nats.html">Messaging (NATS)</a>
-                         </li>
-                         <li class="">
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
                          </li>
                          <li class="">

--- a/subnavs/_pivotalcf-subnav-2-9.erb
+++ b/subnavs/_pivotalcf-subnav-2-9.erb
@@ -631,9 +631,6 @@
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                            </li>
                            <li class="">
-                              <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/messaging-nats.html">Messaging (NATS)</a>
-                           </li>
-                           <li class="">
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
                            </li>
                            <li class="">


### PR DESCRIPTION
We are removing the messaging-nats page and all hyperlinks to said paid
because:
- the document does not facilitate operator/app developer understanding
and is more suited for tile developers
- the document contents are a copy-paste from the NATS docs
- information about NATS is documented elsewhere

[#174578977](https://www.pivotaltracker.com/story/show/174578977)

✨  Can you please propagate this change for 2.7 -> master

Links to all related PRs: 
* https://github.com/cloudfoundry/docs-cloudfoundry-concepts/pull/145
* https://github.com/cloudfoundry/docs-book-cloudfoundry/pull/102
* https://github.com/pivotal-cf/docs-book-windows/pull/2
* https://github.com/pivotal-cf/docs-ops-manager/pull/92
* https://github.com/pivotal-cf/docs-partials/pull/25
* https://github.com/pivotal-cf/docs-pas/pull/2
* https://github.com/pivotal-cf/docs-pcf-security/pull/115


cc: @jrussett