### PR TITLE
Consolidate TCP Routing pages

### DIFF
--- a/subnavs/_pivotalcf-subnav-2-10.erb
+++ b/subnavs/_pivotalcf-subnav-2-10.erb
@@ -811,10 +811,7 @@
                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/custom-load-balancer.html">Using Your Own Load Balancer</a>
                         </li>
                         <li class="">
-                           <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling TCP Routing</a>
-                        </li>
-                        <li class="">
-                           <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/tcp-routing-ert-config.html">Configuring TCP Routing in <%= vars.app_runtime_abbr %></a>
+                           <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling and Configuring TCP Routing</a>
                         </li>
                         <li class="">
                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling_ipv6.html">Enabling IPv6 for Hosted Apps</a>

--- a/subnavs/_pivotalcf-subnav-2-11.erb
+++ b/subnavs/_pivotalcf-subnav-2-11.erb
@@ -655,10 +655,7 @@
                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/custom-load-balancer.html">Using Your Own Load Balancer</a>
                      </li>
                      <li class="">
-                        <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling TCP Routing</a>
-                     </li>
-                     <li class="">
-                        <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/tcp-routing-ert-config.html">Configuring TCP Routing in <%= vars.app_runtime_abbr %></a>
+                        <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling and Configuring TCP Routing</a>
                      </li>
                      <li class="">
                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling_ipv6.html">Enabling IPv6 for Hosted Apps</a>

--- a/subnavs/_pivotalcf-subnav-2-7.erb
+++ b/subnavs/_pivotalcf-subnav-2-7.erb
@@ -799,10 +799,7 @@
                          <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/custom-load-balancer.html">Using Your Own Load Balancer</a>
                        </li>
                        <li class="">
-                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling TCP Routing</a>
-                       </li>
-                       <li class="">
-                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/tcp-routing-ert-config.html">Configuring TCP Routing in <%= vars.app_runtime_abbr %></a>
+                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling and Configuring TCP Routing</a>
                        </li>
                        <li class="">
                          <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling_ipv6.html">Enabling IPv6 for Hosted Apps</a>

--- a/subnavs/_pivotalcf-subnav-2-8.erb
+++ b/subnavs/_pivotalcf-subnav-2-8.erb
@@ -811,10 +811,7 @@
                          <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/custom-load-balancer.html">Using Your Own Load Balancer</a>
                        </li>
                        <li class="">
-                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling TCP Routing</a>
-                       </li>
-                       <li class="">
-                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/tcp-routing-ert-config.html">Configuring TCP Routing in <%= vars.app_runtime_abbr %></a>
+                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling and Configuring TCP Routing</a>
                        </li>
                        <li class="">
                          <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling_ipv6.html">Enabling IPv6 for Hosted Apps</a>

--- a/subnavs/_pivotalcf-subnav-2-9.erb
+++ b/subnavs/_pivotalcf-subnav-2-9.erb
@@ -805,10 +805,7 @@
                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/custom-load-balancer.html">Using Your Own Load Balancer</a>
                         </li>
                         <li class="">
-                           <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling TCP Routing</a>
-                        </li>
-                        <li class="">
-                           <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/operating/tcp-routing-ert-config.html">Configuring TCP Routing in <%= vars.app_runtime_abbr %></a>
+                           <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling-tcp-routing.html">Enabling and Configuring TCP Routing</a>
                         </li>
                         <li class="">
                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/adminguide/enabling_ipv6.html">Enabling IPv6 for Hosted Apps</a>


### PR DESCRIPTION
## The Change
Merges content of:
- docs-cf-admin/enabling-tcp-routing
- docs-operating-pas/tcp-routing-ert-config

into → docs-cf-admin/enabling-tcp-routing

Removes links to docs-operating-pas/tcp-routing-ert-config.

Tracker: [#174580463](https://www.pivotaltracker.com/story/show/174580463)

## PR Acceptance Notes
Please backport this change to TAS `2.7`.

Related PRs:
- cloudfoundry/docs-cf-admin#192
- pivotal-cf/docs-operating-pas#39
- pivotal-cf/docs-partials#28