### PR TITLE
Remove redundant gorouter arch doc

### DIFF
--- a/subnavs/_pivotalcf-subnav-2-10.erb
+++ b/subnavs/_pivotalcf-subnav-2-10.erb
@@ -625,9 +625,6 @@
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                            </li>
                            <li class="">
-                              <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
-                           </li>
-                           <li class="">
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/uaa.html">User Account and Authentication (UAA) Server</a>
                            </li>
                            <li class="">

--- a/subnavs/_pivotalcf-subnav-2-11.erb
+++ b/subnavs/_pivotalcf-subnav-2-11.erb
@@ -469,9 +469,6 @@
                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                      </li>
                      <li class="">
-                        <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
-                     </li>
-                     <li class="">
                         <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/uaa.html">User Account and Authentication (UAA) Server</a>
                      </li>
                      <li class="">

--- a/subnavs/_pivotalcf-subnav-2-7.erb
+++ b/subnavs/_pivotalcf-subnav-2-7.erb
@@ -613,9 +613,6 @@
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                          </li>
                          <li class="">
-                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
-                         </li>
-                         <li class="">
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/uaa.html">User Account and Authentication (UAA) Server</a>
                          </li>
                          <li class="">

--- a/subnavs/_pivotalcf-subnav-2-8.erb
+++ b/subnavs/_pivotalcf-subnav-2-8.erb
@@ -625,9 +625,6 @@
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                          </li>
                          <li class="">
-                            <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
-                         </li>
-                         <li class="">
                             <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/uaa.html">User Account and Authentication (UAA) Server</a>
                          </li>
                          <li class="">

--- a/subnavs/_pivotalcf-subnav-2-9.erb
+++ b/subnavs/_pivotalcf-subnav-2-9.erb
@@ -619,9 +619,6 @@
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cc-blobstore.html">Cloud Controller Blobstore</a>
                            </li>
                            <li class="">
-                              <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/router.html">Gorouter</a>
-                           </li>
-                           <li class="">
                               <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/uaa.html">User Account and Authentication (UAA) Server</a>
                            </li>
                            <li class="">


### PR DESCRIPTION
## The Change
tl;dr: The information contained on that page was represented elsewhere and the page no longer needs to exist.

- the home for the majority of this content is in:
  - `docs-cloudfoundry-concepts/cf-routing-architecture.html`
  - `docs-cf-admin/troubleshooting-router-error-responses.html`

- Removes the following file and all links to file: `docs-cloudfoundry-concepts/architecture/router.html(.md.erb)`
- change link destinations to a more appropriate page
  - usually `docs-cloudfoundry-concepts/cf-routing-architecture.html`
- reorganize the flow of `docs-cloudfoundry-concepts/cf-routing-architecture.html`

PivotalTracker: [#174579096](https://www.pivotaltracker.com/story/show/174579096)

## Backports
Please backport these changes to TAS 2.7.

## Related PRs
- cloudfoundry/docs-cloudfoundry-concepts/pull/148
- cloudfoundry/docs-cf-admin/pull/193
- cloudfoundry/docs-book-cloudfoundry/pull/105
- pivotal-cf/docs-book-windows/pull/4
- pivotal-cf/docs-operating-pas/pull/40
- pivotal-cf/docs-partials/pull/29
- pivotal-cf/docs-pcf-windows/pull/73
- cloudfoundry/docs-routing/pull/3
- pivotal-cf/docs-tiledev/pull/106