### PR TITLE
Remove "Skip SSL Certificate Verification"

### DIFF
--- a/core/2-11/_networking-is.html.md.erb
+++ b/core/2-11/_networking-is.html.md.erb
@@ -22,7 +22,6 @@ To configure the **Networking** pane:
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/tls_cipher_suites_haproxy" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_router_tls_forward" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_hsts_config_cloudform" %>
-1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ssl_verification" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http_disable" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/insecure_cookies" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/zipkin_enable" %>

--- a/core/2-11/_networking-master.html.md.erb
+++ b/core/2-11/_networking-master.html.md.erb
@@ -55,7 +55,6 @@ To configure the **Networking** pane:
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/tls_cipher_suites_haproxy" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_router_tls_forward" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_hsts_config_cloudform" %>
-1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ssl_verification" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http_disable" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/insecure_cookies" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/zipkin_enable" %>

--- a/core/2-11/_ssl_termin_gorouter_lb_pcf.html.md.erb
+++ b/core/2-11/_ssl_termin_gorouter_lb_pcf.html.md.erb
@@ -49,9 +49,6 @@ To configure SSL termination on the Gorouter and load balancer in <%= vars.app_r
     1. In the **Instances** dropdown for the **HAProxy** job, select `0` instances.
     1. Click **Save**.
 
-1. (Optional) If you are not using SSL encryption or if you are using self-signed certificates, you can select the **Disable SSL certificate verification for this environment** checkbox. Selecting this checkbox also disables SSL verification for route services.
-  <p class="note"><strong>Note:</strong> Select this checkbox only for development and testing environments. Do not select it for production environments.</p>
-
 1. (Optional) If you do not want the Gorouter to accept any non-encrypted HTTP traffic, select the **Disable HTTP on the Gorouter and HAProxy** checkbox.
 
 1. Click **Save**.

--- a/core/2-11/_ssl_termin_gorouter_pcf.html.md.erb
+++ b/core/2-11/_ssl_termin_gorouter_pcf.html.md.erb
@@ -20,9 +20,6 @@ To configure SSL termination on the Gorouter in <%= vars.app_runtime_abbr %>:
 
 1. Under **HAProxy forwards all requests to the Gorouter over TLS**, select **Disable**.
 
-1. (Optional) If you are not using SSL encryption or if you are using self-signed certificates, you can select the **Disable SSL certificate verification for this environment** checkbox. Selecting this checkbox also disables SSL verification for route services.
-  <p class="note"><strong>Note:</strong> Select this checkbox only for development and testing environments. Do not select it for production environments.</p>
-
 1. (Optional) If you do not want the Gorouter to accept any non-encrypted HTTP traffic, select the **Disable HTTP on the Gorouter and HAProxy** checkbox.
 
 1. Click **Save**.

--- a/core/2-11/_ssl_termin_haproxy_pcf.html.md.erb
+++ b/core/2-11/_ssl_termin_haproxy_pcf.html.md.erb
@@ -60,9 +60,6 @@ To configure SSL termination on HAProxy in <%= vars.app_runtime_abbr %>:
     * Enable the **Include subdomains** checkbox to force browsers to use HTTPS requests for all component subdomains.
     * Select the **Enable preload** checkbox to force instances of Google Chrome, Firefox, and Safari that access your HAProxy to refer to their built-in lists of known hosts that require HTTPS, of which HAProxy is one. This ensures that the first contact a browser has with your HAProxy is an HTTPS request, even if the browser has not yet received an HSTS header from HAProxy.
 
-1. (Optional) If you are not using SSL encryption or if you are using self-signed certificates, you can select the **Disable SSL certificate verification for this environment** checkbox. This also disables SSL verification for route services.
-    <p class="note"><strong>Note:</strong> Select this checkbox only for development and testing environments. Do not select it for production environments.</p>
-
 1. (Optional) If you do not want the Gorouter to accept any non-encrypted HTTP traffic, select the **Disable HTTP on the Gorouter and HAProxy** checkbox.
 
 1. Under **TLS termination point**, select **Infrastructure load balancer**.

--- a/core/2-11/_ssl_termin_lb_only_pcf.html.md.erb
+++ b/core/2-11/_ssl_termin_lb_only_pcf.html.md.erb
@@ -38,9 +38,6 @@ To configure SSL termination on the load balancer only in <%= vars.app_runtime_a
 
 1. Under **HAProxy forwards all requests to the Gorouter over TLS**, select **Disable**.
 
-1. (Optional) If you are not using SSL encryption or if you are using self-signed certificates, you can select the **Disable SSL certificate verification for this environment** checkbox. Selecting this checkbox also disables SSL verification for route services.
-  <p class="note"><strong>Note:</strong> Select this checkbox only for development and testing environments. Do not select it for production environments.</p>
-
 1. (Optional) If you do not want the Gorouter to accept any non-encrypted HTTP traffic, enable the **Disable HTTP on the Gorouter and HAProxy** checkbox.
 
 1. Click **Save**.

--- a/core/2-11/_ssl_verification.html.md.erb
+++ b/core/2-11/_ssl_verification.html.md.erb
@@ -1,2 +1,0 @@
-If you are not using SSL encryption or if you are using self-signed certificates, select the **Disable SSL certificate verification for this environment** checkbox. Selecting this checkbox also disables SSL verification for route services and disables mutual TLS app identity verification.
-  <p class="note"><strong>Note:</strong> For production deployments, <%= vars.company_name %> does not recommend disabling SSL certificate verification.</p>


### PR DESCRIPTION
## The Change
- Makes `ha_proxy.skip_cert_verify` (Skip SSL Certificate Verification)
unconfigurable and defaulted to `false`
- Removes the form from the tile UI
- Adds migration to prevent upgrading when this feature is configured
`true`
- Removes all documentation referencing to this setting
- Updates Ops Man documentation for case when users want to provide
their own self-signed certificate

[#174811172](https://www.pivotaltracker.com/story/show/174811172)

Co-authored-by: Josh Russett <jrussett@vmware.com>
Co-authored-by: Ryan Hall <hallr@vmware.com>

## Backports
None

## Related PRs
#### Tiles
- pivotal-cf/p-runtime#1826
- pivotal-cf/p-isolation-segment#503
#### Docs
- pivotal-cf/docs-partials#31
- cloudfoundry/docs-cf-admin#194
- pivotal-cf/docs-operating-pas#41
- pivotal-cf/docs-pivotalcf-console#16