### PR TITLE
Update link to docs for modifying TCP ports

### DIFF
--- a/core/2-10/_tcp_routing_enable.html.md.erb
+++ b/core/2-10/_tcp_routing_enable.html.md.erb
@@ -6,7 +6,7 @@ TCP routing is disabled by default. You should enable this feature if your DNS s
       <p class="note"><strong>Note:</strong> If you configured AWS for <%= vars.platform_name %> manually, enter <code>1024-1123</code> which corresponds to the rules you created for <code><%= vars.product_name_lc %>-tcp-elb</code>.</p>
       * To allocate a list of ports:
          1. Enter a single port in the **TCP routing ports** field.
-         1. After deploying <%= vars.app_runtime_abbr %>, follow the procedure in the [Configuring a List of TCP Routing Ports](https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#tcp-port-config) in _<%= vars.app_runtime_full %> v2.3 Release Notes_ to add TCP routing ports using the cf CLI.
+         1. After deploying <%= vars.app_runtime_abbr %>, follow these steps to [modify TCP ports](../adminguide/enabling-tcp-routing.html#modify-ports) using the cf CLI.
    1. (Optional) For **TCP request timeout**, modify the default value of 300 seconds. This field determines when the TCP router closes idle connections from clients to apps that use TCP routes. You may want to increase this value to enable developers to push apps that require long-running idle connections with clients.
    1. Follow these additional instructions based on your IaaS:
       <table>

--- a/core/2-11/_tcp_routing_enable.html.md.erb
+++ b/core/2-11/_tcp_routing_enable.html.md.erb
@@ -6,7 +6,7 @@ TCP routing is disabled by default. You should enable this feature if your DNS s
       <p class="note"><strong>Note:</strong> If you configured AWS for <%= vars.platform_name %> manually, enter <code>1024-1123</code> which corresponds to the rules you created for <code><%= vars.product_name_lc %>-tcp-elb</code>.</p>
       * To allocate a list of ports:
          1. Enter a single port in the **TCP routing ports** field.
-         1. After deploying <%= vars.app_runtime_abbr %>, follow the procedure in the [Configuring a List of TCP Routing Ports](https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#tcp-port-config) in _<%= vars.app_runtime_full %> v2.3 Release Notes_ to add TCP routing ports using the cf CLI.
+         1. After deploying <%= vars.app_runtime_abbr %>, follow these steps to [modify TCP ports](../adminguide/enabling-tcp-routing.html#modify-ports) using the cf CLI.
    1. (Optional) For **TCP request timeout**, modify the default value of 300 seconds. This field determines when the TCP router closes idle connections from clients to apps that use TCP routes. You may want to increase this value to enable developers to push apps that require long-running idle connections with clients.
    1. Follow these additional instructions based on your IaaS:
       <table>

--- a/core/2-7/_tcp_routing_enable.html.md.erb
+++ b/core/2-7/_tcp_routing_enable.html.md.erb
@@ -6,7 +6,7 @@ TCP routing is disabled by default. You should enable this feature if your DNS s
       <p class="note"><strong>Note:</strong> If you configured AWS for <%= vars.platform_name %> manually, enter <code>1024-1123</code> which corresponds to the rules you created for <code><%= vars.product_name_lc %>-tcp-elb</code>.</p>
       * To allocate a list of ports:
          1. Enter a single port in the **TCP routing ports** field.
-         1. After deploying <%= vars.app_runtime_abbr %>, follow the procedure in the [Configuring a List of TCP Routing Ports](https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#tcp-port-config) in _<%= vars.app_runtime_full %> v2.3 Release Notes_ to add TCP routing ports using the cf CLI.
+         1. After deploying <%= vars.app_runtime_abbr %>, follow these steps to [modify TCP ports](../adminguide/enabling-tcp-routing.html#modify-ports) using the cf CLI.
    1. (Optional) For **TCP request timeout**, modify the default value of 300 seconds. This field determines when the TCP router closes idle connections from clients to apps that use TCP routes. You may want to increase this value to enable developers to push apps that require long-running idle connections with clients.
    1. Follow these additional instructions based on your IaaS:
       <table>

--- a/core/2-8/_tcp_routing_enable.html.md.erb
+++ b/core/2-8/_tcp_routing_enable.html.md.erb
@@ -6,7 +6,7 @@ TCP routing is disabled by default. You should enable this feature if your DNS s
       <p class="note"><strong>Note:</strong> If you configured AWS for <%= vars.platform_name %> manually, enter <code>1024-1123</code> which corresponds to the rules you created for <code><%= vars.product_name_lc %>-tcp-elb</code>.</p>
       * To allocate a list of ports:
          1. Enter a single port in the **TCP routing ports** field.
-         1. After deploying <%= vars.app_runtime_abbr %>, follow the procedure in the [Configuring a List of TCP Routing Ports](https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#tcp-port-config) in _<%= vars.app_runtime_full %> v2.3 Release Notes_ to add TCP routing ports using the cf CLI.
+         1. After deploying <%= vars.app_runtime_abbr %>, follow these steps to [modify TCP ports](../adminguide/enabling-tcp-routing.html#modify-ports) using the cf CLI.
    1. (Optional) For **TCP request timeout**, modify the default value of 300 seconds. This field determines when the TCP router closes idle connections from clients to apps that use TCP routes. You may want to increase this value to enable developers to push apps that require long-running idle connections with clients.
    1. Follow these additional instructions based on your IaaS:
       <table>

--- a/core/2-9/_tcp_routing_enable.html.md.erb
+++ b/core/2-9/_tcp_routing_enable.html.md.erb
@@ -6,7 +6,7 @@ TCP routing is disabled by default. You should enable this feature if your DNS s
       <p class="note"><strong>Note:</strong> If you configured AWS for <%= vars.platform_name %> manually, enter <code>1024-1123</code> which corresponds to the rules you created for <code><%= vars.product_name_lc %>-tcp-elb</code>.</p>
       * To allocate a list of ports:
          1. Enter a single port in the **TCP routing ports** field.
-         1. After deploying <%= vars.app_runtime_abbr %>, follow the procedure in the [Configuring a List of TCP Routing Ports](https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#tcp-port-config) in _<%= vars.app_runtime_full %> v2.3 Release Notes_ to add TCP routing ports using the cf CLI.
+         1. After deploying <%= vars.app_runtime_abbr %>, follow these steps to [modify TCP ports](../adminguide/enabling-tcp-routing.html#modify-ports) using the cf CLI.
    1. (Optional) For **TCP request timeout**, modify the default value of 300 seconds. This field determines when the TCP router closes idle connections from clients to apps that use TCP routes. You may want to increase this value to enable developers to push apps that require long-running idle connections with clients.
    1. Follow these additional instructions based on your IaaS:
       <table>


### PR DESCRIPTION
Earlier link referenced release notes for 2.3, which referenced docs in
PDF form for 1.12. New link references existing doc in the same version
on the web.