### PR TITLE
Update Gorouter drain timeout description

### DIFF
--- a/core/2-10/_networking-master.html.md.erb
+++ b/core/2-10/_networking-master.html.md.erb
@@ -67,7 +67,7 @@ To configure the **Networking** pane:
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/keepalive_connections" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_timeout_backend" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/frontend_idle_timeout" %>
-1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. The default value is `900`.
+1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. Set the value lower than back end request timeout and idle timeout to reduce the drain time during deploys. The default value is `900`.
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_unhealthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_healthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http_headers_to_log" %>

--- a/core/2-11/_networking-master.html.md.erb
+++ b/core/2-11/_networking-master.html.md.erb
@@ -66,7 +66,7 @@ To configure the **Networking** pane:
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/keepalive_connections" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_timeout_backend" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/frontend_idle_timeout" %>
-1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. The default value is `900`.
+1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. Set the value lower than back end request timeout and idle timeout to reduce the drain time during deploys. The default value is `900`.
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_unhealthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_healthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http_headers_to_log" %>

--- a/core/2-7/_networking-master.html.md.erb
+++ b/core/2-7/_networking-master.html.md.erb
@@ -67,7 +67,7 @@ To configure the **Networking** pane:
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/keepalive_connections" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_timeout_backend" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/frontend_idle_timeout" %>
-1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. The default value is `900`.
+1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. Set the value lower than back end request timeout and idle timeout to reduce the drain time during deploys. The default value is `900`.
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_unhealthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_healthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http_headers_to_log" %>

--- a/core/2-8/_networking-master.html.md.erb
+++ b/core/2-8/_networking-master.html.md.erb
@@ -67,7 +67,7 @@ To configure the **Networking** pane:
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/keepalive_connections" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_timeout_backend" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/frontend_idle_timeout" %>
-1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. The default value is `900`.
+1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. Set the value lower than back end request timeout and idle timeout to reduce the drain time during deploys. The default value is `900`.
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_unhealthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_healthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http_headers_to_log" %>

--- a/core/2-9/_networking-master.html.md.erb
+++ b/core/2-9/_networking-master.html.md.erb
@@ -67,7 +67,7 @@ To configure the **Networking** pane:
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/keepalive_connections" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_timeout_backend" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/frontend_idle_timeout" %>
-1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. The default value is `900`.
+1. (Optional) Use **Gorouter drain timeout** to specify the amount of time, in seconds, that the Gorouter continues to serve existing connections before shutting down. After the timeout is reached, all remaining connections are terminated so the Gorouter can restart. Set the value lower than back end request timeout and idle timeout to reduce the drain time during deploys. The default value is `900`.
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_unhealthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/lb_healthy_threshold" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http_headers_to_log" %>


### PR DESCRIPTION
Clarify that drain timeout should be lower than backend request timeout to reduce drain time during deploys

The drain timeout for Gorouter sets a maximum for how long to continue
serving existing connections before shutting down. However, "backend
request timeout" also sets a maximum for how long to continue serving an
existing connection or request more generally. Therefore, the drain
timeout must be lower than the request timeout for it to have any impact
on reducing drain times.

[#172726778](https://www.pivotaltracker.com/story/show/172726778)