### PR TITLE
Add link to CF CLI reference guide to subnavigation for TAS 2.10 and

### DIFF
--- a/subnavs/_pivotalcf-subnav-2-10.erb
+++ b/subnavs/_pivotalcf-subnav-2-10.erb
@@ -1108,7 +1108,10 @@
                      <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/cf-cli/develop-cli-plugins.html">Developing cf CLI Plugins</a>
                   </li>
                   <li class="">
-                     <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/cf-cli/cf-help.html">Cloud Foundry CLI Reference Guide</a>
+                     <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/cf-cli/cf-help.html">Cloud Foundry CLI v6 Reference Guide</a>
+                  </li>
+                  <li class="">
+                     <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/cf-cli/cf7-help.html">Cloud Foundry CLI v7 Reference Guide</a>
                   </li>
                   <li class="">
                      <a href="https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/devguide/v3-commands.html">Using Experimental cf CLI Commands</a>


### PR DESCRIPTION
2.11

Not sure how ordering works, but this PR depends on the new v7 help pages being deployed to production pivotal docs for TAS 2.10 and 2.11.
(https://github.com/cloudfoundry/docs-cf-cli/commit/e62e7027964e7bbe56eef1f30c03fe718af5e290)
[#174630523](https://www.pivotaltracker.com/story/show/174630523)