### PR TITLE
Update RMQ doc to remove incorrect TLS information

### DIFF
--- a/services/_prepare-tls-v2.html.md.erb
+++ b/services/_prepare-tls-v2.html.md.erb
@@ -99,7 +99,7 @@ follow this workflow to enable TLS for <%= product_full %>:
     1.  <a href="#credhub-creds">Find the CredHub Credentials in <%= vars.ops_manager %></a> below
     3.  <a href='#add-ca-cert'> Add the CA Certificate</a> below
 
-<% if vars.product_full.include?("MySQL") %>
+<% if vars.product_full.include?("RabbitMQ") %>
 <% else %>
     These procedures are unnecessary if you are on TAS for VMs v2.7.21 or later, v2.8.4
     or later, v2.9.4 or later, or v2.10.


### PR DESCRIPTION
RMQ requires that you add CA cert to credhub regardless of PAS version.