### PR TITLE
mysql: Add known issue around TLS 1.2

### DIFF
--- a/mysql/_tls_12-ki.html.md.erb
+++ b/mysql/_tls_12-ki.html.md.erb
@@ -1,0 +1,4 @@
++ **TLS 1.2 is required even when the checkbox to restrict TLS 1.2 is unchecked**.
+  If the single node and leader-follower service instances are upgraded, this may cause applications to fail to connect
+  to the service instance if they don't support TLS 1.2 or use an old MySQL connector.
+  (e.g. applications using mysql-connector/j older than 8.0.8 or 5.1.44 will fail). HA and Multi-Site instances are unaffected.


### PR DESCRIPTION
This is a new known issue that only affects MySQL for VMs 2.10.0 

[#176253774](https://www.pivotaltracker.com/story/show/176253774)

Authored-by: Shaan Sapra <shsapra@vmware.com>