### PR TITLE
Add docs for the router ca cert properties

### DIFF
--- a/core/2-10/_networking-is.html.md.erb
+++ b/core/2-10/_networking-is.html.md.erb
@@ -11,7 +11,8 @@ To configure the **Networking** pane:
 	<p class="note"><strong>Note:</strong> If you rely on HAProxy for a feature in <%= vars.app_runtime_abbr %> and you want isolated networking for this isolation segment, you may want to deploy the HAProxy provided by the <%= vars.segment_runtime_full %> tile.</p>
 
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_router_cert_config" %>
-1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_haproxy_ca" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_ca_certs_old" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_ca_certs_new" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/min_tls_version" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_balancing_algorithm" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ip_logging" %>

--- a/core/2-10/_router_ca_certs_new.html.md.erb
+++ b/core/2-10/_router_ca_certs_new.html.md.erb
@@ -1,0 +1,16 @@
+(optional) Some newer versions of TAS have the field "Certificate Authorities trusted by the Gorouter for back ends and route services"
+followed by the field "Certificate Authorities trusted by the Gorouter for client requests". These fields allow the operator greater flexibility
+when configuring which CA certs Gorouter trusts for different interactions.
+
+  1. When validating requests using mutual TLS to back ends and route services, the Gorouter trusts multiple certificate
+  authorities (CAs) by default. An operator can add additional CAs for the Gorouter to trust for these situations in the
+  field "Certificate Authorities trusted by the Gorouter for back ends and route services".
+  1. For backwards compatibility with older versions before these properties were split, an operator can configure the
+  exact same CA certs to be trusted for clients requests as are trusted for back ends and route services. An operator
+  can do this by going to the **Certificate Authorities trusted by the Gorouter for client requests** property and
+  selecting **Trust certs provided in "Certificate Authorities trusted by the Gorouter for back ends and route services"**
+  1. If an operator wants Gorouter to trust only a particular set of CAs for client requests, then the operator can
+  go to the **Certificate Authorities trusted by the Gorouter for client requests** property and select
+  **Only trust the following Certificate Authorities**. Then a text box will appear and the operator can enter the CAs.
+  When this option is selected Gorouter will only trust the provided CAs for client requests. It will not trust any
+  well known CAs provided with the stemcell.

--- a/core/2-10/_router_ca_certs_old.html.md.erb
+++ b/core/2-10/_router_ca_certs_old.html.md.erb
@@ -1,0 +1,3 @@
+(optional) Some older versions of TAS have the field **Certificate Authorities trusted by the Gorouter**.
+When validating requests using mutual TLS the Gorouter trusts multiple certificate authorities (CAs) by default.
+An operator can add additional CAs for the Gorouter to trust here.

--- a/core/2-11/_networking-is.html.md.erb
+++ b/core/2-11/_networking-is.html.md.erb
@@ -11,7 +11,7 @@ To configure the **Networking** pane:
 	<p class="note"><strong>Note:</strong> If you rely on HAProxy for a feature in <%= vars.app_runtime_abbr %> and you want isolated networking for this isolation segment, you may want to deploy the HAProxy provided by the <%= vars.segment_runtime_full %> tile.</p>
 
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_router_cert_config" %>
-1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_haproxy_ca" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_ca_certs" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/min_tls_version" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_balancing_algorithm" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ip_logging" %>

--- a/core/2-11/_router_ca_certs.html.md.erb
+++ b/core/2-11/_router_ca_certs.html.md.erb
@@ -1,0 +1,16 @@
+(optional) Some newer versions of TAS have the field "Certificate Authorities trusted by the Gorouter for back ends and route services"
+followed by the field "Certificate Authorities trusted by the Gorouter for client requests". These fields allow the operator greater flexibility
+when configuring which CA certs Gorouter trusts for different interactions.
+
+  1. When validating requests using mutual TLS to back ends and route services, the Gorouter trusts multiple certificate
+  authorities (CAs) by default. An operator can add additional CAs for the Gorouter to trust for these situations in the
+  field "Certificate Authorities trusted by the Gorouter for back ends and route services".
+  1. For backwards compatibility with older versions before these properties were split, an operator can configure the
+  exact same CA certs to be trusted for clients requests as are trusted for back ends and route services. An operator
+  can do this by going to the **Certificate Authorities trusted by the Gorouter for client requests** property and
+  selecting **Trust certs provided in "Certificate Authorities trusted by the Gorouter for back ends and route services"**
+  1. If an operator wants Gorouter to trust only a particular set of CAs for client requests, then the operator can
+  go to the **Certificate Authorities trusted by the Gorouter for client requests** property and select
+  **Only trust the following Certificate Authorities**. Then a text box will appear and the operator can enter the CAs.
+  When this option is selected Gorouter will only trust the provided CAs for client requests. It will not trust any
+  well known CAs provided with the stemcell.

--- a/core/2-7/_networking-is.html.md.erb
+++ b/core/2-7/_networking-is.html.md.erb
@@ -11,7 +11,8 @@ To configure the **Networking** pane:
 	<p class="note"><strong>Note:</strong> If you rely on HAProxy for a feature in <%= vars.app_runtime_abbr %> and you want isolated networking for this isolation segment, you may want to deploy the HAProxy provided by the <%= vars.segment_runtime_full %> tile.</p>
 
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_router_cert_config" %>
-1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_haproxy_ca" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_ca_certs_old" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_ca_certs_new" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/min_tls_version" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_balancing_algorithm" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ip_logging" %>

--- a/core/2-7/_router_ca_certs_new.html.md.erb
+++ b/core/2-7/_router_ca_certs_new.html.md.erb
@@ -1,0 +1,16 @@
+(optional) Some newer versions of TAS have the field "Certificate Authorities trusted by the Gorouter for back ends and route services"
+followed by the field "Certificate Authorities trusted by the Gorouter for client requests". These fields allow the operator greater flexibility
+when configuring which CA certs Gorouter trusts for different interactions.
+
+  1. When validating requests using mutual TLS to back ends and route services, the Gorouter trusts multiple certificate
+  authorities (CAs) by default. An operator can add additional CAs for the Gorouter to trust for these situations in the
+  field "Certificate Authorities trusted by the Gorouter for back ends and route services".
+  1. For backwards compatibility with older versions before these properties were split, an operator can configure the
+  exact same CA certs to be trusted for clients requests as are trusted for back ends and route services. An operator
+  can do this by going to the **Certificate Authorities trusted by the Gorouter for client requests** property and
+  selecting **Trust certs provided in "Certificate Authorities trusted by the Gorouter for back ends and route services"**
+  1. If an operator wants Gorouter to trust only a particular set of CAs for client requests, then the operator can
+  go to the **Certificate Authorities trusted by the Gorouter for client requests** property and select
+  **Only trust the following Certificate Authorities**. Then a text box will appear and the operator can enter the CAs.
+  When this option is selected Gorouter will only trust the provided CAs for client requests. It will not trust any
+  well known CAs provided with the stemcell.

--- a/core/2-7/_router_ca_certs_old.html.md.erb
+++ b/core/2-7/_router_ca_certs_old.html.md.erb
@@ -1,0 +1,3 @@
+(optional) Some older versions of TAS have the field **Certificate Authorities trusted by the Gorouter**.
+When validating requests using mutual TLS the Gorouter trusts multiple certificate authorities (CAs) by default.
+An operator can add additional CAs for the Gorouter to trust here.

--- a/core/2-9/_networking-is.html.md.erb
+++ b/core/2-9/_networking-is.html.md.erb
@@ -11,7 +11,8 @@ To configure the **Networking** pane:
 	<p class="note"><strong>Note:</strong> If you rely on HAProxy for a feature in <%= vars.app_runtime_abbr %> and you want isolated networking for this isolation segment, you may want to deploy the HAProxy provided by the <%= vars.segment_runtime_full %> tile.</p>
 
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_router_cert_config" %>
-1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_haproxy_ca" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_ca_certs_old" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_ca_certs_new" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/min_tls_version" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_balancing_algorithm" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ip_logging" %>

--- a/core/2-9/_router_ca_certs_new.html.md.erb
+++ b/core/2-9/_router_ca_certs_new.html.md.erb
@@ -1,0 +1,16 @@
+(optional) Some newer versions of TAS have the field "Certificate Authorities trusted by the Gorouter for back ends and route services"
+followed by the field "Certificate Authorities trusted by the Gorouter for client requests". These fields allow the operator greater flexibility
+when configuring which CA certs Gorouter trusts for different interactions.
+
+  1. When validating requests using mutual TLS to back ends and route services, the Gorouter trusts multiple certificate
+  authorities (CAs) by default. An operator can add additional CAs for the Gorouter to trust for these situations in the
+  field "Certificate Authorities trusted by the Gorouter for back ends and route services".
+  1. For backwards compatibility with older versions before these properties were split, an operator can configure the
+  exact same CA certs to be trusted for clients requests as are trusted for back ends and route services. An operator
+  can do this by going to the **Certificate Authorities trusted by the Gorouter for client requests** property and
+  selecting **Trust certs provided in "Certificate Authorities trusted by the Gorouter for back ends and route services"**
+  1. If an operator wants Gorouter to trust only a particular set of CAs for client requests, then the operator can
+  go to the **Certificate Authorities trusted by the Gorouter for client requests** property and select
+  **Only trust the following Certificate Authorities**. Then a text box will appear and the operator can enter the CAs.
+  When this option is selected Gorouter will only trust the provided CAs for client requests. It will not trust any
+  well known CAs provided with the stemcell.

--- a/core/2-9/_router_ca_certs_old.html.md.erb
+++ b/core/2-9/_router_ca_certs_old.html.md.erb
@@ -1,0 +1,3 @@
+(optional) Some older versions of TAS have the field **Certificate Authorities trusted by the Gorouter**.
+When validating requests using mutual TLS the Gorouter trusts multiple certificate authorities (CAs) by default.
+An operator can add additional CAs for the Gorouter to trust here.


### PR DESCRIPTION
[#175826420](https://www.pivotaltracker.com/story/show/175826420)

* removed link to partial that describes a property that is no longer present in IST (that I could find) 
* added docs in 2.7, 2.9, 2.10 for the old property "Certificate Authorities trusted by the Gorouter"
* added docs in 2.7, 2.9, 2.10, 2.11 for the new properties "Certificate Authorities trusted by the Gorouter for back ends and route services" and "Certificate Authorities trusted by the Gorouter for client requests"
* the new properties are being added with this PAS request (https://github.com/pivotal/pas-requests/issues/896) and are not released yet. 

❓ I want to be able to point to these docs in the release notes when then next patch versions of TAS is released. Given that I have documented the "old" and "new" properties, is it okay for these docs to be published ahead of the patches? 

🙏  please let me know if you have any questions or comments! I tried to be as clear as I could, but this stuff is difficult and I always appreciate your input!