### PR TITLE
Correct default value of 'Maximum valid packages (stages droplets) per app'

### DIFF
--- a/core/2-10/_max_droplets_packages_config.html.md.erb
+++ b/core/2-10/_max_droplets_packages_config.html.md.erb
@@ -4,9 +4,9 @@ To configure the **File Storage** pane:
 
 1. Select **File Storage**.
 
-1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
-1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
 1. Under **File storage backup level**, select what you want to back up from your blobstores:
 	* **Complete file storage backup** includes the entire blobstore. This includes droplets, packages, and buildpacks.

--- a/core/2-11/_max_droplets_packages_config.html.md.erb
+++ b/core/2-11/_max_droplets_packages_config.html.md.erb
@@ -4,9 +4,9 @@ To configure the **File Storage** pane:
 
 1. Select **File Storage**.
 
-1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
-1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
 1. Under **File storage backup level**, select what you want to back up from your blobstores:
 	* **Complete file storage backup** includes the entire blobstore. This includes droplets, packages, and buildpacks.

--- a/core/2-12/_max_droplets_packages_config.html.md.erb
+++ b/core/2-12/_max_droplets_packages_config.html.md.erb
@@ -4,9 +4,9 @@ To configure the **File Storage** pane:
 
 1. Select **File Storage**.
 
-1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
-1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
 1. Under **File storage backup level**, select what you want to back up from your blobstores:
 	* **Complete file storage backup** includes the entire blobstore. This includes droplets, packages, and buildpacks.

--- a/core/2-7/_max_droplets_packages_config.html.md.erb
+++ b/core/2-7/_max_droplets_packages_config.html.md.erb
@@ -4,9 +4,9 @@ To configure the **File Storage** pane:
 
 1. Select **File Storage**.
 
-1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.recommended_by %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.recommended_by %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
-1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.recommended_by %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.recommended_by %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
 1. Under **Configure file storage backup level**, select what you want to back up from your blobstores:
 	* **Complete file storage backup** includes the entire blobstore. This includes droplets, packages, and buildpacks.

--- a/core/2-8/_max_droplets_packages_config.html.md.erb
+++ b/core/2-8/_max_droplets_packages_config.html.md.erb
@@ -4,9 +4,9 @@ To configure the **File Storage** pane:
 
 1. Select **File Storage**.
 
-1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.recommended_by %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.recommended_by %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
-1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.recommended_by %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.recommended_by %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
 1. Under **Configure file storage backup level**, select what you want to back up from your blobstores:
 	* **Complete file storage backup** includes the entire blobstore. This includes droplets, packages, and buildpacks.

--- a/core/2-9/_max_droplets_packages_config.html.md.erb
+++ b/core/2-9/_max_droplets_packages_config.html.md.erb
@@ -4,9 +4,9 @@ To configure the **File Storage** pane:
 
 1. Select **File Storage**.
 
-1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid packages that your app can store, not including the package for the current droplet, enter a value in the **Maximum valid packages per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
-1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `5`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
+1. To set the maximum number of recent valid droplets that your app can store, not including the package for the current droplet, enter a value in the **Maximum staged droplets per app** field. <%= vars.company_name %> recommends leaving the default value of `2`. However, you can lower the value if you have strict storage requirements and want to use less disk space.
 
 1. Under **File storage backup level**, select what you want to back up from your blobstores:
 	* **Complete file storage backup** includes the entire blobstore. This includes droplets, packages, and buildpacks.


### PR DESCRIPTION
The correct default value is `2` based on TAS tile configuration:- 

- https://github.com/pivotal/tas/blob/main/tas/properties/system_blobstore.yml#L2-L12.

```
- name: system_blobstore_ccdroplet_max_staged_droplets_stored
  type: integer
  configurable: true
  default: 2
  constraints:
    min: 1

- name: system_blobstore_ccpackage_max_valid_packages_stored
  type: integer
  configurable: true
  default: 2
```

Correct the outdated value `5` in the doc.