### PR TITLE
Add configuration step for HTTP/2

### DIFF
--- a/core/2-12/_http2.html.md.erb
+++ b/core/2-12/_http2.html.md.erb
@@ -1,0 +1,4 @@
+(Optional) To disable HTTP/2 ingress and egress for the Gorouter,
+deselect the **Enables the HTTP/2 protocol for communicating with apps** checkbox.
+HTTP/2 is enabled by default. For more information about HTTP/2 routing,
+see [Supporting HTTP/2](../adminguide/supporting-http2.html).

--- a/core/2-12/_networking-main.html.md.erb
+++ b/core/2-12/_networking-main.html.md.erb
@@ -44,6 +44,7 @@ To configure the **Networking** pane:
 
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/haproxy_router_cert_config" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_haproxy_ca" %>
+1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/http2" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/min_tls_version" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/router_balancing_algorithm" %>
 1. <%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ip_logging" %>


### PR DESCRIPTION
- New configuration option introduced in 2.12

[cloudfoundry/routing-release#200]

Authored-by: Greg Cobb <gcobb@pivotal.io>